### PR TITLE
fix: handle indicators without indicator names

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -7,5 +7,5 @@
     "shell-version": [
         "46"
     ],
-    "version": "1.0"
+    "version": "1.0.1"
 }

--- a/src/containerService.js
+++ b/src/containerService.js
@@ -4,7 +4,7 @@ import {gettext as _} from 'resource:///org/gnome/shell/extensions/extension.js'
 
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 
-import {getRoleName, getDisplayName, readJSON, saveJSON} from './utils/utils.js';
+import {getRoleName} from './utils/utils.js';
 
 export default class ContainerService extends GObject.Object {
     static {
@@ -138,11 +138,11 @@ export default class ContainerService extends GObject.Object {
         for (let i = 0; i < children.length; i++) {
             let container = children[i];
             let actor = container.get_first_child();
-            let actorName = getDisplayName(actor);
+            let actorName = getRoleName(this._containerName.get(container));
 
             // conditions to exclude
             if (!actor.visible) continue;
-            if (actorName === "System") continue;
+            if (actorName === "quickSettings") continue;
             
             if (container && actor.is_visible()) {
                 // accessible name could change, so push the raw role first

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -28,13 +28,3 @@ export function getRoleName(role) {
     roleName = role.split('/');         // for parsing ayatana appindicators
     return roleName[roleName.length - 1].split('@')[0];
 }
-
-export function getDisplayName(actor) {
-    if (actor.accessible_name === "") {
-        const indicatorName = actor?._indicator?._uniqueId.split('@/');
-        return indicatorName[indicatorName.length - 1];
-    }
-    
-    // native GTK widget
-    return actor.accessible_name
-}


### PR DESCRIPTION
In rare cases app indicators may have included an indicator name
- inidicatorName returns null, causing TypeError
- fixed by using role name assigned by the gnome shell instead