### PR TITLE
feat: add clear button in settings page

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -111,10 +111,6 @@ export default class Lilypad extends Extension {
 
         setIcon(this._settings.get_boolean("show-icons"));
 
-        let clearButton = new PopupMenu.PopupMenuItem(_("Clear"));
-        clearButton.connect('activate', this._containerService.clearOrder.bind(this._containerService));
-        indicator.menu.addMenuItem(clearButton);
-
         let settingsItem = new PopupMenu.PopupMenuItem(_('Settings'));
         settingsItem.connect('activate', () => this.openPreferences());
         indicator.menu.addMenuItem(settingsItem);

--- a/src/containerService.js
+++ b/src/containerService.js
@@ -70,6 +70,11 @@ export default class ContainerService extends GObject.Object {
         let showIcons     = this._settings.get_strv('show-icons');
         const roleOrder   = this.getOrder();
 
+        // if order was reset, change to CLOSED icon
+        if (rightBoxOrder.length === 0) {
+            this._setIconsVisibility(false);
+        }        
+
         roleOrder.forEach((role) => {
             // insert new roles to arrange
             const roleName = getRoleName(role);

--- a/ui/prefs.ui
+++ b/ui/prefs.ui
@@ -67,5 +67,35 @@
       </object>
     </child>
 
+    <child>
+      <object class="AdwPreferencesGroup">
+        <property name="title" translatable="yes">Clear Order</property>
+        <property name="description" translatable="yes">Clears indicators stored in settings</property>
+        <property name="header-suffix">
+          <object class="GtkButton" id="clear-button">
+            <style>
+              <class name="destructive-action" />
+            </style>
+            <property name="halign">start</property>
+            <property name="valign">center</property>
+            <property name="margin-end">15</property>
+            <child>
+              <object class="GtkBox">
+                <property name="margin-start">15</property>
+                <property name="margin-end">15</property>
+                <property name="margin-top">5</property>
+                <property name="margin-bottom">5</property>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="label" translatable="yes">Clear</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+          </object>
+        </property>
+      </object>
+    </child>
+
   </template>
 </interface>


### PR DESCRIPTION
Removed "Clear" from popup menu to prevent misclicks.

Added Clear button to settings page, with confirmation prompt.
-confirming YES: clears stored icon orders and reads an updated order