### PR TITLE
Blacklist Support

### DIFF
--- a/schemas/org.gnome.shell.extensions.lilypad.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.lilypad.gschema.xml
@@ -15,6 +15,11 @@
             <summary>Icons in collapsible Lilypad menu</summary>
         </key>
 
+        <key type="as" name="ignored-order">
+            <default>[]</default>
+            <summary>Icons ignored by Lilypad</summary>
+        </key>
+
         <key type="b" name="reorder">
             <default>false</default>
         </key>

--- a/src/containerService.js
+++ b/src/containerService.js
@@ -130,6 +130,7 @@ export default class ContainerService extends GObject.Object {
 
     // Get current order of icons in the top bar
     getOrder() {
+        let ignoredOrder = this._settings.get_strv('ignored-order');
         // GET widget role name
         this._containerName = new Map();
         for (const role in Main.panel.statusArea) {
@@ -143,14 +144,15 @@ export default class ContainerService extends GObject.Object {
         for (let i = 0; i < children.length; i++) {
             let container = children[i];
             let actor = container.get_first_child();
-
+       
 	    if (this._containerName.get(container) === undefined) continue;
+        console.log("lilypad", this._containerName.get(container), container)
             let actorName = getRoleName(this._containerName.get(container));
 
             // conditions to exclude
             if (!actor.visible) continue;
-            if (actorName === "quickSettings") continue;
-            
+            if (actorName === "quickSettings" ||  ignoredOrder.includes(actorName)) continue;
+
             if (container && actor.is_visible()) {
                 // accessible name could change, so push the raw role first
                 roleOrder.push(this._containerName.get(container));

--- a/ui/prefs.ui
+++ b/ui/prefs.ui
@@ -69,6 +69,32 @@
 
     <child>
       <object class="AdwPreferencesGroup">
+        <property name="title">Blacklisted Icons</property>
+        <property name="description">List of icons that will manage their own placement, ignored by Lilypad. It's recommended to reload the GNOME Shell for changes to take effect.</property>
+        <child>
+          <object class="GtkBox">
+            <property name="orientation">1</property>
+            <child>
+              <object class="AdwClamp">
+                <property name="maximum-size">600</property>
+                <child>
+                  <object class="GtkListBox" id="ignored-order">
+                    <style>
+                      <class name="boxed-list"/>
+                    </style>
+              
+
+                  </object>
+                </child>
+              </object>
+            </child>
+          </object>
+        </child>
+      </object>
+    </child>
+
+    <child>
+      <object class="AdwPreferencesGroup">
         <property name="title" translatable="yes">Clear Order</property>
         <property name="description" translatable="yes">Clears indicators stored in settings</property>
         <property name="header-suffix">


### PR DESCRIPTION
- Adds an option to blacklist icons of which lilipad wouldn't change the position. 
- Fixes https://github.com/shendrew/Lilypad/issues/13

![9f57282815be53dc-600x338](https://github.com/user-attachments/assets/6c52a6a2-c757-49cc-bfc3-1bb16a4608c4)
