### PR TITLE
fix: arrow icons background

### DIFF
--- a/icons/closed_icon_arrow.svg
+++ b/icons/closed_icon_arrow.svg
@@ -1,13 +1,55 @@
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- Uploaded to: SVG Repo, www.svgrepo.com, Transformed by: SVG Repo Mixer Tools -->
-<svg fill="#000000" height="800px" width="800px" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 330 330" xml:space="preserve">
-  <g id="SVGRepo_bgCarrier" stroke-width="0"/>
-  <g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"/>
-  <g id="SVGRepo_iconCarrier">
-    <!-- Outer circle -->
-    <path d="M165,0C74.019,0,0,74.019,0,165s74.019,165,165,165s165-74.019,165-165S255.981,0,165,0z" fill="black"/>
-    <!-- Inner arrow -->
-    <path d="M205.606,234.394c5.858,5.857,5.858,15.355,0,21.213C202.678,258.535,198.839,260,195,260s-7.678-1.464-10.606-4.394l-80-79.998c-2.813-2.813-4.394-6.628-4.394-10.606c0-3.978,1.58-7.794,4.394-10.607l80-80.002c5.857-5.858,15.355-5.858,21.213,0c5.858,5.857,5.858,15.355,0,21.213l-69.393,69.396L205.606,234.394z" fill="white"/>
-  </g>
-</svg>
 
+<svg
+   fill="#000000"
+   height="800px"
+   width="800px"
+   version="1.1"
+   id="Layer_1"
+   viewBox="0 0 330 330"
+   xml:space="preserve"
+   stroke="#000000"
+   sodipodi:docname="open_icon_arrow (Kopie).svg"
+   inkscape:version="1.4.4 (dcaf3e7d9e, 2026-05-05)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><defs
+   id="defs2">
+    
+    
+    
+    
+  </defs><sodipodi:namedview
+   id="namedview2"
+   pagecolor="#ffffff"
+   bordercolor="#000000"
+   borderopacity="0.25"
+   inkscape:showpageshadow="2"
+   inkscape:pageopacity="0.0"
+   inkscape:pagecheckerboard="0"
+   inkscape:deskcolor="#d1d1d1"
+   inkscape:zoom="1.4425"
+   inkscape:cx="399.65338"
+   inkscape:cy="400"
+   inkscape:window-width="2560"
+   inkscape:window-height="1365"
+   inkscape:window-x="0"
+   inkscape:window-y="0"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="Layer_1" />
+  <g
+   id="SVGRepo_bgCarrier"
+   stroke-width="0"
+   transform="matrix(-1,0,0,1,350.00463,0)" />
+  <g
+   id="SVGRepo_tracerCarrier"
+   stroke-linecap="round"
+   stroke-linejoin="round"
+   transform="matrix(-1,0,0,1,350.00463,0)" />
+  <path
+   d="m 124.39863,175.605 80,80.002 c 2.928,2.928 6.767,4.393 10.606,4.393 3.839,0 7.678,-1.464 10.606,-4.394 5.858,-5.857 5.858,-15.355 0,-21.213 l -69.393,-69.396 69.393,-69.392 c 5.858,-5.857 5.858,-15.355 0,-21.213 -5.857,-5.858 -15.355,-5.858 -21.213,0 l -80,79.998 c -2.814,2.813 -4.394,6.628 -4.394,10.606 0.001,3.98 1.581,7.796 4.395,10.609 z"
+   fill="#ffffff"
+   id="path2" />
+</svg>

--- a/icons/open_icon_arrow.svg
+++ b/icons/open_icon_arrow.svg
@@ -1,13 +1,53 @@
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- Uploaded to: SVG Repo, www.svgrepo.com, Transformed by: SVG Repo Mixer Tools -->
-<svg fill="#000000" height="800px" width="800px" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 330 330" xml:space="preserve" stroke="#000000">
-  <g id="SVGRepo_bgCarrier" stroke-width="0"/>
-  <g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"/>
-  <g id="SVGRepo_iconCarrier">
-    <!-- Outer circle -->
-    <path d="M165,0C74.019,0,0,74.019,0,165s74.019,165,165,165s165-74.019,165-165S255.981,0,165,0z" fill="black"/>
-    <!-- Inner arrow -->
-    <path d="M225.606,175.605l-80,80.002C142.678,258.535,138.839,260,135,260s-7.678-1.464-10.606-4.394c-5.858-5.857-5.858-15.355,0-21.213l69.393-69.396l-69.393-69.392c-5.858-5.857-5.858-15.355,0-21.213c5.857-5.858,15.355-5.858,21.213,0l80,79.998c2.814,2.813,4.394,6.628,4.394,10.606C230,168.976,228.42,172.792,225.606,175.605z" fill="white"/>
-  </g>
-</svg>
 
+<svg
+   fill="#000000"
+   height="800px"
+   width="800px"
+   version="1.1"
+   id="Layer_1"
+   viewBox="0 0 330 330"
+   xml:space="preserve"
+   stroke="#000000"
+   sodipodi:docname="open_icon_arrow.svg"
+   inkscape:version="1.4.4 (dcaf3e7d9e, 2026-05-05)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><defs
+   id="defs2">
+    
+    
+    
+    
+  </defs><sodipodi:namedview
+   id="namedview2"
+   pagecolor="#ffffff"
+   bordercolor="#000000"
+   borderopacity="0.25"
+   inkscape:showpageshadow="2"
+   inkscape:pageopacity="0.0"
+   inkscape:pagecheckerboard="0"
+   inkscape:deskcolor="#d1d1d1"
+   inkscape:zoom="1.4425"
+   inkscape:cx="399.65338"
+   inkscape:cy="400"
+   inkscape:window-width="2560"
+   inkscape:window-height="1365"
+   inkscape:window-x="0"
+   inkscape:window-y="0"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="Layer_1" />
+  <g
+   id="SVGRepo_bgCarrier"
+   stroke-width="0" />
+  <g
+   id="SVGRepo_tracerCarrier"
+   stroke-linecap="round"
+   stroke-linejoin="round" />
+  <path
+   d="m 225.606,175.605 -80,80.002 C 142.678,258.535 138.839,260 135,260 c -3.839,0 -7.678,-1.464 -10.606,-4.394 -5.858,-5.857 -5.858,-15.355 0,-21.213 l 69.393,-69.396 -69.393,-69.392 c -5.858,-5.857 -5.858,-15.355 0,-21.213 5.857,-5.858 15.355,-5.858 21.213,0 l 80,79.998 c 2.814,2.813 4.394,6.628 4.394,10.606 -0.001,3.98 -1.581,7.796 -4.395,10.609 z"
+   fill="#ffffff"
+   id="path2" />
+</svg>


### PR DESCRIPTION
A visual fix for the new arrow icons. Removes the background color to support GNOME panels with different colors. 

And thank you for the helpful extension :)