### PR TITLE
fix: guard against null refs during disable/enable cycle

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -69,7 +69,8 @@ export default class Lilypad extends Extension {
         Panel.Panel.prototype._originalAddToStatusArea =
       Panel.Panel.prototype.addToStatusArea;
         const rearrange = () => {
-            // preserves extension scope
+            // Stale destroy signals from other indicators can call this after disable()
+            if (!this._containerService) return;
             this._containerService.arrange();
             this._updateIndicatorVisibility();
         };
@@ -158,15 +159,24 @@ export default class Lilypad extends Extension {
     }
 
     disable() {
+        // Stop auto-collapse timer first to prevent callbacks firing during teardown
+        clearTimeout(this._timerId);
+        this._timerId = null;
+
         this._signalHandler.forEach((signal) =>
             signal.object.disconnect(signal.id),
         );
+        this._signalHandler = [];
 
         Panel.Panel.prototype.addToStatusArea =
       Panel.Panel.prototype._originalAddToStatusArea;
         Panel.Panel.prototype._originalAddToStatusArea = null;
 
+        // Restore icon visibility before teardown
         this._containerService?.destroy();
+        // Null containerService before destroying indicator, because
+        // indicator.destroy() can trigger rearrange() via destroy signals
+        // on other indicators still connected from enable().
         this._containerService = null;
 
         this._indicator?.destroy();
@@ -178,8 +188,6 @@ export default class Lilypad extends Extension {
         this._openIcon = null;
 
         this._settings = null;
-        clearTimeout(this._timerId);
-        this._timerId = null;
 
         console.log('Lilypad extension stopped.');
     }
@@ -272,6 +280,8 @@ export default class Lilypad extends Extension {
     }
 
     _updateIndicatorVisibility() {
+        // Can be called via stale destroy signal callbacks after disable()
+        if (!this._settings || !this._containerService) return false;
         const hide = this._settings.get_int('hide-indicator');
 
         if (hide === HideExtension.NEVER.value) {


### PR DESCRIPTION
# Motivation

When gnome-shell triggers a disable/enable cycle (e.g. on screen lock/unlock or suspend/resume), the `rearrange()` closure and `_updateIndicatorVisibility()` can be called after `disable()` has already `nulled` `_containerService` and `_settings`, causing "this._containerService is null" JS errors.

# Changes

- Add null guard in `rearrange()` closure
- Add null guard in `_updateIndicatorVisibility()`
- Reorder `disable()`: clear timer first, null `containerService`
  before destroying indicator to prevent re-entrant `rearrange()`
- Clear `_signalHandler` array after disconnecting
