### PR TITLE
fix: handle null regex match in getRoleName

### DIFF
--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -15,6 +15,7 @@ export function getRoleName(role) {
     //* ignore wildcards from indicator IDs
     const regex = /((\d)*[A-Z]+(\d)*)+/gi;
     const keyWords = roleName.match(regex);
+    if (!keyWords) return roleName;
 
     const display = keyWords.join('_');
     return display;


### PR DESCRIPTION
## Summary

- `String.match()` returns `null` when no matches are found, causing `getRoleName()` to crash with `TypeError: keyWords is null` when calling `.join()` on the result
- Indicators with role names containing no alphanumeric characters (e.g. special characters from appindicators) trigger this crash
- Returns raw `roleName` as fallback when regex produces no matches

## Context

Observed in GNOME Shell 46 logs during startup — certain appindicators (e.g. Slack) register with role names that don't match the `/((\d)*[A-Z]+(\d)*)+/gi` regex, crashing the entire `arrange()` flow and leaving Lilypad non-functional.